### PR TITLE
fix(backend): child widget type does not handle

### DIFF
--- a/backend/pydatafront/decorator/__init__.py
+++ b/backend/pydatafront/decorator/__init__.py
@@ -84,8 +84,6 @@ def get_type_widget_prop(function_arg_type_name, index, function_arg_widget):
             widget = function_arg_widget[index]
     else:
         widget = ""
-    if widget == "sheet" or widget == "simple":
-        widget = [widget]
     if function_arg_type_name in __supported_basic_types:
         if function_arg_type_name == "int":
             return {

--- a/frontend/src/components/TexteaFunction/ObjectFieldExtendedTemplate.tsx
+++ b/frontend/src/components/TexteaFunction/ObjectFieldExtendedTemplate.tsx
@@ -67,8 +67,7 @@ const ObjectFieldExtendedTemplate = (props: ObjectFieldProps) => {
     const isArrayInSheet =
       elementProps.schema.type === "array" &&
       elementProps.schema.hasOwnProperty("widget") &&
-      Array.isArray(elementProps.schema.widget) &&
-      elementProps.schema.widget.includes("sheet");
+      elementProps.schema.widget === "sheet";
     const hasArrayExample =
       isArray &&
       elementProps.schema.hasOwnProperty("example") &&


### PR DESCRIPTION
The backend does not handle the type of child widget, which can make the rendering of widgets in simple or sheet not conform to expectations.

You can reproduce this problem.

Python Code:

```python
from typing import List
from pydatafront.decorator import textea_export

@textea_export(
    path="backend",
    description="reproduce",
    a={
        "treat_as": "column",
        "widget": "switch"
    }
)
def backend(a: List[bool]):
    return {
        "result": a
    }
```

![image](https://user-images.githubusercontent.com/47273265/188987464-bbf24ade-4540-4d60-8734-db63dbfb80c3.png)

After fixing:

![image](https://user-images.githubusercontent.com/47273265/188987711-50aea390-81a2-4f45-99dc-71bde29bc634.png)
