### PR TITLE
feature(sheet option): add `slider`, `switch` and `checkbox`

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -139,6 +139,26 @@ def slider_test(a: List[int], b: float):
         "b": b
     }
 
+
+@textea_export(
+    path="sheet_test",
+    description="sweet sheet",
+    a={
+        "treat_as": "column",
+        "widget": ["sheet", "slider"]
+    },
+    b={
+        "treat_as": "column",
+        "widget": ["sheet", "switch"]
+    }
+)
+def sheet_test(a: List[int], b: List[bool]):
+    return {
+        "a": a,
+        "b": b
+    }
+
+
 @textea_export(
     path="calc_literal",
     description="perform some basic math calculation",

--- a/frontend/src/components/Common/SliderValueLabel.tsx
+++ b/frontend/src/components/Common/SliderValueLabel.tsx
@@ -1,0 +1,15 @@
+import { SliderValueLabelProps, Tooltip } from "@mui/material";
+import React from "react";
+
+export default function SliderValueLabel(props: SliderValueLabelProps) {
+  return (
+    <Tooltip
+      enterTouchDelay={0}
+      placement="top"
+      title={props.value}
+      sx={{ zIndex: 1500 }}
+    >
+      {props.children}
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/SheetComponents/SheetCheckBox.tsx
+++ b/frontend/src/components/SheetComponents/SheetCheckBox.tsx
@@ -1,0 +1,41 @@
+import { SheetInterface } from "./SheetInterface";
+import React from "react";
+import {
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+} from "@mui/material";
+
+export default function SheetCheckBox(props: SheetInterface) {
+  const [checked, setChecked] = React.useState<boolean>(props.params.value);
+
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
+    if (props.customChange instanceof Function) {
+      props.customChange(
+        props.params.row.id,
+        props.params.field,
+        event.target.checked
+      );
+    }
+  };
+
+  return (
+    <FormControl fullWidth>
+      <FormGroup>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={checked}
+              onChange={onChange}
+              sx={{ margin: "0 auto" }}
+            />
+          }
+          label={""}
+          sx={{ width: "100%", margin: "0 auto" }}
+        />
+      </FormGroup>
+    </FormControl>
+  );
+}

--- a/frontend/src/components/SheetComponents/SheetInterface.tsx
+++ b/frontend/src/components/SheetComponents/SheetInterface.tsx
@@ -1,0 +1,8 @@
+import { GridRenderCellParams } from "@mui/x-data-grid";
+
+export interface SheetInterface {
+  widget: string;
+  type: string;
+  params: GridRenderCellParams<any, any, any>;
+  customChange: object;
+}

--- a/frontend/src/components/SheetComponents/SheetSlider.tsx
+++ b/frontend/src/components/SheetComponents/SheetSlider.tsx
@@ -1,0 +1,41 @@
+import { SheetInterface } from "./SheetInterface";
+import React from "react";
+import {
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  Switch,
+} from "@mui/material";
+
+export default function SheetSwitch(props: SheetInterface) {
+  const [checked, setChecked] = React.useState<boolean>(props.params.value);
+
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
+    if (props.customChange instanceof Function) {
+      props.customChange(
+        props.params.row.id,
+        props.params.field,
+        event.target.checked
+      );
+    }
+  };
+
+  return (
+    <FormControl fullWidth>
+      <FormGroup>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={checked}
+              onChange={onChange}
+              sx={{ margin: "0 auto" }}
+            />
+          }
+          label={""}
+          sx={{ width: "100%", margin: "0 auto" }}
+        />
+      </FormGroup>
+    </FormControl>
+  );
+}

--- a/frontend/src/components/SheetComponents/SheetSwitch.tsx
+++ b/frontend/src/components/SheetComponents/SheetSwitch.tsx
@@ -1,0 +1,41 @@
+import { SheetInterface } from "./SheetInterface";
+import React from "react";
+import {
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  Switch,
+} from "@mui/material";
+
+export default function SheetSwitch(props: SheetInterface) {
+  const [checked, setChecked] = React.useState<boolean>(props.params.value);
+
+  const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(event.target.checked);
+    if (props.customChange instanceof Function) {
+      props.customChange(
+        props.params.row.id,
+        props.params.field,
+        event.target.checked
+      );
+    }
+  };
+
+  return (
+    <FormControl fullWidth>
+      <FormGroup>
+        <FormControlLabel
+          control={
+            <Switch
+              checked={checked}
+              onChange={onChange}
+              sx={{ margin: "0 auto" }}
+            />
+          }
+          label={""}
+          sx={{ width: "100%", margin: "0 auto" }}
+        />
+      </FormGroup>
+    </FormControl>
+  );
+}

--- a/frontend/src/components/TexteaFunction/ObjectFieldExtendedTemplate.tsx
+++ b/frontend/src/components/TexteaFunction/ObjectFieldExtendedTemplate.tsx
@@ -31,6 +31,7 @@ import {
   HideGridColMenuItem,
   GridFilterMenuItem,
   GridColumnsMenuItem,
+  GridRowId,
 } from "@mui/x-data-grid";
 import {
   bindHover,
@@ -41,6 +42,9 @@ import {
 import HoverPopover from "material-ui-popup-state/HoverPopover";
 import { usePopupState } from "material-ui-popup-state/hooks";
 import { GridColType } from "@mui/x-data-grid/models/colDef/gridColType";
+import SheetSwitch from "../SheetComponents/SheetSwitch";
+import SheetSlider from "../SheetComponents/SheetSlider";
+import SheetCheckBox from "../SheetComponents/SheetCheckBox";
 
 let rowIdCounter = 0;
 
@@ -299,11 +303,27 @@ const ObjectFieldExtendedTemplate = (props: ObjectFieldProps) => {
       if (isArrayInSheet) {
         arrayElementsInSheet.push(elementContent);
         const itemType = elementProps.schema.items.type;
+        const itemWidget = elementProps.schema.items.widget;
         const gridColType = itemType === "integer" ? "number" : itemType;
         let newColumn: GridColDef = {
           field: elementProps.name,
           type: gridColType,
           editable: !hasArrayWhitelist,
+        };
+        const handleCustomComponentChange = (
+          rowId: GridRowId,
+          field: string,
+          value: any
+        ) => {
+          setRows((prevRows) => {
+            const newRows = [...prevRows];
+            newRows.map((row) => {
+              if (row.id === rowId) {
+                row[field] = value;
+              }
+            });
+            return newRows;
+          });
         };
         if (itemType === "integer") {
           newColumn = {
@@ -314,6 +334,82 @@ const ObjectFieldExtendedTemplate = (props: ObjectFieldProps) => {
             }),
           };
         }
+
+        switch (itemType) {
+          case "number":
+            if (itemWidget.indexOf("slider") !== -1) {
+              newColumn = {
+                ...newColumn,
+                width: 200,
+                editable: false,
+                renderCell: (params) => {
+                  return (
+                    <SheetSlider
+                      widget={itemWidget}
+                      type={itemType}
+                      params={params}
+                      customChange={handleCustomComponentChange}
+                    />
+                  );
+                },
+              };
+            }
+            break;
+          case "integer":
+            if (itemWidget.indexOf("slider") !== -1) {
+              newColumn = {
+                ...newColumn,
+                editable: false,
+                width: 200,
+                renderCell: (params) => {
+                  return (
+                    <SheetSlider
+                      widget={itemWidget}
+                      type={itemType}
+                      params={params}
+                      customChange={handleCustomComponentChange}
+                    />
+                  );
+                },
+              };
+            }
+            break;
+          case "boolean":
+            if (itemWidget === "switch") {
+              newColumn = {
+                ...newColumn,
+                editable: false,
+                renderCell: (params) => {
+                  return (
+                    <SheetSwitch
+                      widget={itemWidget}
+                      type={itemType}
+                      params={params}
+                      customChange={handleCustomComponentChange}
+                    />
+                  );
+                },
+              };
+            }
+            if (itemWidget === "checkbox") {
+              newColumn = {
+                ...newColumn,
+                editable: false,
+                renderCell: (params) => {
+                  return (
+                    <SheetCheckBox
+                      widget={itemWidget}
+                      type={itemType}
+                      params={params}
+                      customChange={handleCustomComponentChange}
+                    />
+                  );
+                },
+              };
+            }
+            break;
+        }
+
         columns.push(newColumn);
       }
     }
@@ -450,6 +546,7 @@ const ObjectFieldExtendedTemplate = (props: ObjectFieldProps) => {
                 selectionModel={selectionModel}
                 onSelectionModelChange={handleSelectionModelChange}
                 onCellEditCommit={handleCellEditCommit}
+                disableSelectionOnClick={true}
                 components={{
                   ColumnMenu: GridColumnMenu,
                 }}

--- a/frontend/src/components/TexteaFunction/TextExtendedWidget.tsx
+++ b/frontend/src/components/TexteaFunction/TextExtendedWidget.tsx
@@ -10,26 +10,12 @@ import {
   Grid,
   Input,
   Slider,
-  SliderValueLabelProps,
   TextField,
-  Tooltip,
   Typography,
 } from "@mui/material";
+import SliderValueLabel from "../Common/SliderValueLabel";
 
 const { getDisplayLabel } = utils;
-
-function valueLabel(props: SliderValueLabelProps) {
-  return (
-    <Tooltip
-      enterTouchDelay={0}
-      placement="top"
-      title={props.value}
-      sx={{ zIndex: 1500 }}
-    >
-      {props.children}
-    </Tooltip>
-  );
-}
 
 const TextExtendedWidget = ({
   id,
@@ -55,7 +41,15 @@ const TextExtendedWidget = ({
     schema.widget !== undefined &&
     (schema.type === "number" || schema.type === "integer") // slider only for float and integer
   ) {
-    const args = JSON.parse(schema.widget.trim().split("slider")[1]);
+    let args = [];
+    if (
+      schema.widget.indexOf("[") === -1 ||
+      schema.widget.indexOf("]") === -1
+    ) {
+      console.warn("slider syntax: slider[min, max, range]");
+    } else {
+      args = JSON.parse(schema.widget.trim().split("slider")[1]);
+    }
     const min = args[0] || 0;
     const max = args[1] || 100;
     const defaultStep = schema.type === "integer" ? 1 : 0.1;
@@ -114,7 +108,7 @@ const TextExtendedWidget = ({
               onChange={handleSliderChange}
               valueLabelDisplay="on"
               components={{
-                ValueLabel: valueLabel,
+                ValueLabel: SliderValueLabel,
               }}
             />
           </Grid>


### PR DESCRIPTION
There is a document on the development of widgets for sheets which will probably be uploaded to Notion this evening or tomorrow (UTC +8).

For the time being, the switch will be used to manually control which components are used, perhaps to be replaced with external configurations in the future.