### PR TITLE
feat: support for kumo callback

### DIFF
--- a/backend/funix/__init__.py
+++ b/backend/funix/__init__.py
@@ -299,6 +299,8 @@ def get_flask_application(
     repo_dir: Optional[str] = None,
     transform: Optional[bool] = False,
     app_secret: Optional[str | bool] = False,
+    __kumo_callback_url: Optional[str] = None,
+    __kumo_callback_token: Optional[str] = None,
 ) -> Flask:
     """
     Get flask application for the funix app.
@@ -313,10 +315,14 @@ def get_flask_application(
         repo_dir (str): If you want to run the app from a git repo, you can specify the directory, default is None
         transform (bool): If you want to enable transform mode, default is False
         app_secret (str | bool): If you want to set an app secret, default is False
+        __kumo_callback_url (str): The Kumo callback url, default is None, do not set it if you don't know what it is.
+        __kumo_callback_token (str): The Kumo callback token, default is None, do not set it if you don't know what
+                                     it is.
 
     Returns:
         flask.Flask: The flask application.
     """
+    decorator.set_kumo_info(__kumo_callback_url, __kumo_callback_token)
     import_from_config(
         file_or_module_name=file_or_module_name,
         lazy=lazy,

--- a/backend/funix/decorator/__init__.py
+++ b/backend/funix/decorator/__init__.py
@@ -391,12 +391,16 @@ def kumo_callback():
     """
     global kumo_callback_url, kumo_callback_token
     if kumo_callback_url and kumo_callback_token:
-        post(
-            kumo_callback_url,
-            json={
-                "token": kumo_callback_token,
-            },
-        )
+        try:
+            post(
+                kumo_callback_url,
+                json={
+                    "token": kumo_callback_token,
+                },
+                timeout=1,
+            )
+        except:
+            pass
 
 
 def funix(


### PR DESCRIPTION
Add a function that reports to Kumo.

Since AWS logs may not be easy to read and are filled with lots of access from spam bots on the internet.

Kumo will generate a report URL and token for Funix to use, which will be requested when the function is executed.

This function only logs the number of calls and does not contain any cookie information or call parameters that can be traced back to an individual and will not be enabled for local/personal cloud deployments by the normal user, only by Kumo.

I will release 0.5.1 for Kumo testing.