### PR TITLE
fix: typing issues of funix()

### DIFF
--- a/backend/funix/decorator/__init__.py
+++ b/backend/funix/decorator/__init__.py
@@ -8,7 +8,7 @@ from importlib import import_module
 from inspect import getsource, isgeneratorfunction, signature
 from secrets import token_hex
 from types import ModuleType
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, ParamSpec, TypeVar
 from uuid import uuid4
 
 from funix.app import app, sock
@@ -189,6 +189,11 @@ def object_is_handled(object_id: int) -> bool:
     return object_id in handled_object
 
 
+P = ParamSpec("P")
+R = TypeVar("R")
+
+RateLimiter = Union[Limiter, list['RateLimiter'], dict[str, 'RateLimiter'], None]
+
 def funix(
     path: Optional[str] = None,
     title: Optional[str] = None,
@@ -211,7 +216,7 @@ def funix(
     pre_fill: PreFillType = None,
     menu: Optional[str] = None,
     default: bool = False,
-    rate_limit: Union[Limiter, list, dict, None] = None,
+    rate_limit: RateLimiter = None,
     reactive: ReactiveType = None,
     print_to_web: bool = False,
     autorun: bool = False,
@@ -268,7 +273,7 @@ def funix(
         Check code for details
     """
 
-    def decorator(function: Callable) -> callable:
+    def decorator(function: Callable[P, R]) -> Callable[P, R]:
         """
         Decorator for functions to convert them to web apps
 

--- a/backend/funix/hint/__init__.py
+++ b/backend/funix/hint/__init__.py
@@ -23,7 +23,7 @@ DestinationType = Optional[Literal["column", "row", "sheet"]]
 For yodas only, the destination of the page.
 """
 
-Parameters = str | tuple
+Parameters = str | tuple[str, ...]
 """
 Parameters.
 
@@ -51,9 +51,9 @@ Acceptable widgets. Implemented now.
 """
 
 WidgetsValue = (
-    list[AcceptableWidgets | tuple[AcceptableWidgets, dict]]
+    list[AcceptableWidgets | tuple[AcceptableWidgets, dict[str, Any]]]
     | AcceptableWidgets
-    | tuple[AcceptableWidgets, dict]
+    | tuple[AcceptableWidgets, dict[str, Any]]
 )
 """
 The value of the `widgets`.
@@ -96,7 +96,7 @@ Examples:
     {("a", "b"): "cell"} -> The parameter `a` and `b` are cells.
 """
 
-WhitelistValues = list[list] | list
+WhitelistValues = list[list[str]] | list[str]
 """
 The value of the `whitelist`.
 
@@ -115,7 +115,7 @@ Examples:
                                               `["a", "b"]`, for `b` the whitelist is `["c", "d"]`.
 """
 
-ExamplesValues = list[list] | list
+ExamplesValues = list[list[str]] | list[str]
 """
 The value of the `examples`.
 
@@ -226,7 +226,7 @@ Examples:
     {"a": {"widget": "sheet"}} -> The parameter `a` has a widget, and the widget is `sheet`.
 """
 
-PreFillArgumentFrom = Callable | tuple[Callable, int]
+PreFillArgumentFrom = Callable[..., Any] | tuple[Callable[..., Any], int]
 """
 Pre-fill argument from.
 
@@ -246,7 +246,7 @@ Examples:
 
 PreFillEmpty = TypeVar("PreFillEmpty")
 
-ReactiveType = Optional[dict[str, Callable | tuple[Callable, dict[str, str]]]]
+ReactiveType = Optional[dict[str, Callable[..., Any] | tuple[Callable[..., Any], dict[str, str]]]]
 """
 Document is on the way
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,5 +51,15 @@ homepage = "https://github.com/TexteaInc/funix"
 [project.scripts]
 funix = "funix.__main__:cli_main"
 
+[tool.pyright]
+include = ["src"]
+exclude = ["**/node_modules", "**/__pycache__"]
+strict = ["src"]
+typeCheckingMode = "strict"
+
+useLibraryCodeForTypes = true
+reportMissingImports = true
+reportMissingTypeStubs = false
+
 [tool.setuptools.packages.find]
 where = ["backend"]


### PR DESCRIPTION
1. fix type annotation of funix() the decorator
2. add `[tool.pyright]` part of pyproject.toml

Closes: https://github.com/TexteaInc/funix/issues/88