### PR TITLE
Auto-init funix_class instances for void constructors

### DIFF
--- a/backend/funix/decorator/magic.py
+++ b/backend/funix/decorator/magic.py
@@ -181,7 +181,7 @@ def get_type_dict(annotation: any) -> dict:
             return {"type": getattr(annotation, "__name__")}
         elif annotation_type_class_name == "range":
             return {"type": "range"}
-        elif annotation_type_class_name in ["UnionType", "_UnionGenericAlias"]:
+        elif annotation_type_class_name in ["Union", "UnionType", "_UnionGenericAlias"]:
             if (
                 len(getattr(annotation, "__args__")) != 2
                 or getattr(annotation, "__args__")[0].__name__ == "NoneType"

--- a/backend/funix/decorator/runtime.py
+++ b/backend/funix/decorator/runtime.py
@@ -256,6 +256,16 @@ class RuntimeClassVisitor(NodeVisitor):
                 )
             )
 
+        # Align class-method default with normal @funix default:
+        # keep auto-run disabled unless user explicitly sets auto_run.
+        if not any(k.arg == "auto_run" for k in funix_decorator.keywords):
+            funix_decorator.keywords.append(
+                keyword(
+                    arg="auto_run",
+                    value=Constant(value=False),
+                )
+            )
+
         funix_decorator.keywords.append(
             keyword(
                 arg="is_class_method",

--- a/backend/funix/decorator/runtime.py
+++ b/backend/funix/decorator/runtime.py
@@ -15,6 +15,7 @@ from _ast import (
     keyword,
 )
 from ast import NodeVisitor, unparse
+from inspect import Parameter, signature
 from typing import Any
 
 import funix
@@ -61,6 +62,36 @@ def set_init_function(cls_name: str, cls: Any):
     set_global_variable("__FUNIX_" + cls_name, cls)
 
 
+def _has_void_constructor(cls: Any) -> bool:
+    """Return True if __init__ only has `self` (or variadics), with no explicit args."""
+    init_sig = signature(cls.__init__)
+    params = list(init_sig.parameters.values())[1:]  # Skip `self`
+    if not params:
+        return True
+    for p in params:
+        if p.kind in (Parameter.VAR_POSITIONAL, Parameter.VAR_KEYWORD):
+            continue
+        return False
+    return True
+
+
+def get_or_init_function(
+    cls_name: str,
+    cls_type: Any,
+    auto_init_when_missing: bool = False,
+) -> Any:
+    """
+    Return class instance from session, optionally auto-initializing it.
+    """
+    inited_class = get_global_variable("__FUNIX_" + cls_name)
+    if inited_class is None and auto_init_when_missing:
+        inited_class = cls_type()
+        set_init_function(cls_name, inited_class)
+    if inited_class is None:
+        raise WrapperException("Class must be inited first!")
+    return inited_class
+
+
 class RuntimeClassVisitor(NodeVisitor):
     """
     The runtime class visitor.
@@ -98,6 +129,7 @@ class RuntimeClassVisitor(NodeVisitor):
             self.class_sock = sock
 
         self.open_function = False
+        self._auto_init_void_constructor = _has_void_constructor(cls)
 
         # keep order number track
         self.number_tracker = 0
@@ -276,6 +308,13 @@ class RuntimeClassVisitor(NodeVisitor):
                 node_doc_string = node.body[0].value.value
 
         if node.name == "__init__":
+            if self._auto_init_void_constructor:
+                funix_decorator.keywords.append(
+                    keyword(
+                        arg="disable",
+                        value=Constant(value=True),
+                    )
+                )
             # new_module.body[0].decorator_list[0].keywords = [
             #     keyword(arg="title", value=Constant(value=self._cls_name))
             # ]
@@ -322,8 +361,12 @@ class RuntimeClassVisitor(NodeVisitor):
                     Assign(
                         targets=[Name(id="_funix_self", ctx=Store())],
                         value=Call(
-                            func=Name(id="get_init_function", ctx=Load()),
-                            args=[Constant(value=self._cls_name)],
+                            func=Name(id="get_or_init_function", ctx=Load()),
+                            args=[
+                                Constant(value=self._cls_name),
+                                Name(id=self._cls_name, ctx=Load()),
+                                Constant(value=self._auto_init_void_constructor),
+                            ],
                             keywords=[],
                         ),
                         lineno=0,

--- a/backend/funix/test/test_auto_init_void_constructor.py
+++ b/backend/funix/test/test_auto_init_void_constructor.py
@@ -1,0 +1,58 @@
+from unittest import TestCase, main
+from unittest.mock import patch
+
+from funix.decorator.runtime import _has_void_constructor, get_or_init_function
+from funix.hint import WrapperException
+
+
+class NoArgCtor:
+    def __init__(self):
+        self.value = 1
+
+
+class WithArgCtor:
+    def __init__(self, x: int):
+        self.value = x
+
+
+class VariadicCtor:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class TestAutoInitVoidConstructor(TestCase):
+    def test_has_void_constructor(self):
+        self.assertTrue(_has_void_constructor(NoArgCtor))
+        self.assertFalse(_has_void_constructor(WithArgCtor))
+        self.assertTrue(_has_void_constructor(VariadicCtor))
+
+    def test_get_or_init_function_existing_instance(self):
+        existing = object()
+        with patch("funix.decorator.runtime.get_global_variable", return_value=existing):
+            got = get_or_init_function("Demo", NoArgCtor, auto_init_when_missing=True)
+        self.assertIs(got, existing)
+
+    def test_get_or_init_function_auto_init(self):
+        captured = {}
+
+        def _capture_setter(name, value):
+            captured["name"] = name
+            captured["value"] = value
+
+        with patch("funix.decorator.runtime.get_global_variable", return_value=None):
+            with patch("funix.decorator.runtime.set_init_function", side_effect=_capture_setter):
+                got = get_or_init_function("Demo", NoArgCtor, auto_init_when_missing=True)
+
+        self.assertIsInstance(got, NoArgCtor)
+        self.assertEqual(captured["name"], "Demo")
+        self.assertIs(captured["value"], got)
+
+    def test_get_or_init_function_requires_init_when_disabled(self):
+        with patch("funix.decorator.runtime.get_global_variable", return_value=None):
+            with self.assertRaises(WrapperException):
+                get_or_init_function("Demo", WithArgCtor, auto_init_when_missing=False)
+
+
+if __name__ == "__main__":
+    main(verbosity=2)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,6 +62,7 @@ import {
   TemplateString,
 } from "./components/Common/TemplateString";
 import PrivacyDialog from "./components/PrivacyDialog";
+import MarkdownDiv from "./components/Common/MarkdownDiv";
 import {
   appSecretAtom,
   backendAtom,
@@ -549,9 +550,8 @@ const App = () => {
                     </IconButton>
                   )}
                 <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-                  <TemplateString
-                    template={theme?.funix_header || "{{org}}"}
-                    records={{
+                  <MarkdownDiv
+                    markdown={stringTemplate(theme?.funix_header || "{{org}}", {
                       org: selectedFunction?.name || "Funix",
                       functionName: selectedFunction?.name || "No name",
                       functionPath: selectedFunction?.path || "No path",
@@ -563,7 +563,8 @@ const App = () => {
                         ? "Yes"
                         : "No",
                       functionModule: selectedFunction?.module || "No module",
-                    }}
+                    })}
+                    isRenderInline={true}
                   />
                 </Typography>
                 {selectedFunction && selectedFunction.secret && (


### PR DESCRIPTION
## Summary
This PR changes `@funix_class()` behavior when a class constructor has no user-facing arguments.

For classes with a void constructor (only `self`, or only variadics like `*args`/`**kwargs`), Funix now auto-initializes the class instance on first member-method invocation and hides the generated `initialize_<Class>` page.

## Why This Feature
- Removes unnecessary UX friction for classes that do not require constructor inputs.
- Matches user expectation: if construction needs no arguments, member methods should be callable immediately.
- Keeps initialization semantics explicit only where needed (constructors with required args).

## Behavior Changes
- `@funix_class` with zero-arg `__init__`:
  - Calling a member method no longer raises "Class must be inited first!".
  - The instance is auto-created lazily on first call.
  - `initialize_<Class>` is not exposed in function list, so users land directly on member methods.
- `@funix_class` with non-void `__init__`:
  - Existing behavior is preserved.
  - Explicit initialization is still required before member methods.

## Code Changes
### `backend/funix/decorator/runtime.py`
- Added `_has_void_constructor(cls)` to detect constructors without explicit parameters.
- Added `get_or_init_function(cls_name, cls_type, auto_init_when_missing)`:
  - Reuses existing session instance when available.
  - Optionally auto-creates and stores an instance when missing.
  - Preserves prior `WrapperException` behavior when auto-init is disabled.
- `RuntimeClassVisitor` now computes `self._auto_init_void_constructor` once per class.
- During AST generation:
  - For `__init__`: appends `disable=True` to hide generated initializer page when constructor is void.
  - For non-static member methods: generated wrapper now calls `get_or_init_function(...)` with auto-init flag instead of `get_init_function(...)`.

### Additional Minor Fixes
- **Class method auto-run default parity**:
  - Generated class methods now default to `auto_run=False` unless explicitly set by `@funix_method(...)`.
  - This aligns class-method behavior with normal `@funix` defaults and prevents unexpected "Continuously Run" toggle visibility.
- **Header markdown rendering**:
  - Top app header now renders markdown in `theme.funix_header` / function titles (e.g., links like `[Goodmem.ai](https://www.goodmem.ai)`).
  - This fixes non-rendered markdown in the Funix header/title bar.

### Tests
Added `backend/funix/test/test_auto_init_void_constructor.py` with coverage for:
- Void constructor detection (`_has_void_constructor`)
- Existing instance retrieval path
- Auto-init path
- Required-init path when auto-init disabled

## Validation
- `python -m unittest funix.test.test_auto_init_void_constructor`
- Manual check with a temporary `@funix_class` demo:
  - `/list` excludes `initialize_*` for void constructor
  - Direct member call succeeds without explicit initialize
- Manual metadata check for class method defaults:
  - `/list` reports `autorun: "disable"` for class methods unless explicitly configured

## Risk / Tradeoff
- For no-arg constructors that perform heavy work or side effects, those effects now occur on first member-method invocation instead of an explicit initialize step.
- This is intentional for the no-arg case, but worth documenting for users who rely on explicit initialization timing.

## Notes
This implementation is backend-driven. Header markdown support includes frontend rendering updates.
